### PR TITLE
Simplify serde interactions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ use error::Error;
 pub enum Flag {
     Default,
     ReverseKey,
-    IntegerKey
+    IntegerKey,
 }
 
 impl Flag {
@@ -23,7 +23,7 @@ impl Flag {
         match self {
             &Flag::ReverseKey => DatabaseFlags::REVERSE_KEY,
             &Flag::IntegerKey => DatabaseFlags::INTEGER_KEY,
-            &Flag::Default => DatabaseFlags::empty()
+            &Flag::Default => DatabaseFlags::empty(),
         }
     }
 }
@@ -126,10 +126,8 @@ impl Config {
 
     /// Add a bucket
     pub fn bucket<S: AsRef<str>>(&mut self, name: S, f: Option<Flag>) -> &mut Config {
-        self.buckets.insert(
-            String::from(name.as_ref()),
-            f.unwrap_or(Flag::Default)
-        );
+        self.buckets
+            .insert(String::from(name.as_ref()), f.unwrap_or(Flag::Default));
         self
     }
 
@@ -157,7 +155,6 @@ impl Config {
             .set_map_size(self.map_size)
             .open(self.path.as_path())
         {
-
             Ok(db) => Ok(db),
             Err(e) => {
                 let _ = fs::remove_dir_all(&self.path);

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -28,8 +28,10 @@ pub trait Encoding: Sized {
 
 /// A trait for types wrapping Serde values
 pub trait SerdeEncoding<T>: Encoding {
+    /// Wraps a serde-compatible type in a `SerdeEncoding`
     fn from_serde(t: T) -> Self;
 
+    /// Unwraps a serde-compatible type from a `SerdeEncoding`
     fn to_serde(self) -> T;
 }
 
@@ -40,7 +42,42 @@ impl<E: Encoding> From<E> for ValueBuf<E> {
 }
 
 #[cfg(feature = "cbor-value")]
-/// CBOR encoding
+/// The cbor encoding allows for any {de|se}rializable type to be read/written to the database
+/// using a ValueBuf, for example:
+///
+/// ```rust
+/// extern crate kv;
+/// extern crate serde;
+/// #[macro_use]
+/// extern crate serde_derive;
+///
+/// use serde::{Deserialize, Serialize};
+/// use kv::cbor::CborEncoding;
+/// use kv::{Manager, Config, ValueBuf, SerdeEncoding};
+///
+/// #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// struct Testing {
+///     a: i32,
+///     b: String
+/// }
+///
+/// fn main() {
+///     let mut mgr = Manager::new();
+///     let mut cfg = Config::default("/tmp/rust-kv");
+///     let handle = mgr.open(cfg).unwrap();
+///     let store = handle.write().unwrap();
+///     let bucket = store.bucket::<&str, ValueBuf<CborEncoding<Testing>>>(None).unwrap();
+///     let mut txn = store.write_txn().unwrap();
+///     let t = Testing{a: 123, b: "abc".to_owned()};
+///     txn.set(&bucket, "testing", CborEncoding::from_serde(t)).unwrap();
+///     txn.commit().unwrap();
+///
+///     let txn = store.read_txn().unwrap();
+///     let buf = txn.get(&bucket, "testing").unwrap();
+///     let v = buf.inner().unwrap();
+///     println!("{:?}", v.to_serde());
+/// }
+/// ```
 pub mod cbor {
     extern crate serde_cbor;
 
@@ -84,7 +121,42 @@ pub mod cbor {
 }
 
 #[cfg(feature = "json-value")]
-/// JSON encoding
+/// The json encoding allows for any {de|se}rializable type to be read/written to the database
+/// using a ValueBuf, for example:
+///
+/// ```rust
+/// extern crate kv;
+/// extern crate serde;
+/// #[macro_use]
+/// extern crate serde_derive;
+///
+/// use serde::{Deserialize, Serialize};
+/// use kv::json::JsonEncoding;
+/// use kv::{Manager, Config, ValueBuf, SerdeEncoding};
+///
+/// #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// struct Testing {
+///     a: i32,
+///     b: String
+/// }
+///
+/// fn main() {
+///     let mut mgr = Manager::new();
+///     let mut cfg = Config::default("/tmp/rust-kv");
+///     let handle = mgr.open(cfg).unwrap();
+///     let store = handle.write().unwrap();
+///     let bucket = store.bucket::<&str, ValueBuf<JsonEncoding<Testing>>>(None).unwrap();
+///     let mut txn = store.write_txn().unwrap();
+///     let t = Testing{a: 123, b: "abc".to_owned()};
+///     txn.set(&bucket, "testing", JsonEncoding::from_serde(t)).unwrap();
+///     txn.commit().unwrap();
+///
+///     let txn = store.read_txn().unwrap();
+///     let buf = txn.get(&bucket, "testing").unwrap();
+///     let v = buf.inner().unwrap();
+///     println!("{:?}", v.to_serde());
+/// }
+/// ```
 pub mod json {
     extern crate serde_json;
 
@@ -128,7 +200,42 @@ pub mod json {
 }
 
 #[cfg(feature = "bincode-value")]
-/// Bincode encoding
+/// The bincode encoding allows for any {de|se}rializable type to be read/written to the database
+/// using a ValueBuf, for example:
+///
+/// ```rust
+/// extern crate kv;
+/// extern crate serde;
+/// #[macro_use]
+/// extern crate serde_derive;
+///
+/// use serde::{Deserialize, Serialize};
+/// use kv::bincode::BincodeEncoding;
+/// use kv::{Manager, Config, ValueBuf, SerdeEncoding};
+///
+/// #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// struct Testing {
+///     a: i32,
+///     b: String
+/// }
+///
+/// fn main() {
+///     let mut mgr = Manager::new();
+///     let mut cfg = Config::default("/tmp/rust-kv");
+///     let handle = mgr.open(cfg).unwrap();
+///     let store = handle.write().unwrap();
+///     let bucket = store.bucket::<&str, ValueBuf<BincodeEncoding<Testing>>>(None).unwrap();
+///     let mut txn = store.write_txn().unwrap();
+///     let t = Testing{a: 123, b: "abc".to_owned()};
+///     txn.set(&bucket, "testing", BincodeEncoding::from_serde(t)).unwrap();
+///     txn.commit().unwrap();
+///
+///     let txn = store.read_txn().unwrap();
+///     let buf = txn.get(&bucket, "testing").unwrap();
+///     let v = buf.inner().unwrap();
+///     println!("{:?}", v.to_serde());
+/// }
+/// ```
 pub mod bincode {
     extern crate bincode;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,4 +35,4 @@ pub use cursor::{Cursor, CursorOp};
 pub use buf::ValueBuf;
 pub use types::{Integer, Key, Value, ValueMut, ValueRef};
 pub use manager::Manager;
-pub use encoding::Encoding;
+pub use encoding::{Encoding, SerdeEncoding};

--- a/src/store.rs
+++ b/src/store.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use lmdb;
 
-use config::{DatabaseFlags, Config};
+use config::{Config, DatabaseFlags};
 use error::Error;
 use txn::Txn;
 use std::collections::HashMap;
@@ -49,9 +49,7 @@ impl Store {
                 Some(bucket_name.clone())
             };
 
-            store
-                .buckets
-                .insert(name, flag.database_flags());
+            store.buckets.insert(name, flag.database_flags());
         }
 
         if !initialized_default {

--- a/src/txn.rs
+++ b/src/txn.rs
@@ -49,7 +49,11 @@ impl<'env> Txn<'env> {
     }
 
     /// Gets the value associated with the given key
-    pub fn get<K: Key, V: Value<'env>>(&'env self, bucket: &Bucket<'env, K, V>, key: K) -> Result<V, Error> {
+    pub fn get<K: Key, V: Value<'env>>(
+        &'env self,
+        bucket: &Bucket<'env, K, V>,
+        key: K,
+    ) -> Result<V, Error> {
         match self {
             &Txn::ReadOnly(ref txn) => Ok(V::from_raw(txn.get(bucket.db(), &key.as_ref())?)),
             &Txn::ReadWrite(ref txn) => Ok(V::from_raw(txn.get(bucket.db(), &key.as_ref())?)),
@@ -93,7 +97,11 @@ impl<'env> Txn<'env> {
     }
 
     /// Deletes the key and value associated with `key` from the database
-    pub fn del<K: Key, V: Value<'env>>(&mut self, bucket: &Bucket<'env, K, V>, key: K) -> Result<(), Error> {
+    pub fn del<K: Key, V: Value<'env>>(
+        &mut self,
+        bucket: &Bucket<'env, K, V>,
+        key: K,
+    ) -> Result<(), Error> {
         match self {
             &mut Txn::ReadOnly(_) => Err(Error::ReadOnly),
             &mut Txn::ReadWrite(ref mut txn) => Ok(txn.del(bucket.db(), &key.as_ref(), None)?),


### PR DESCRIPTION
These changes not only allow for serialization and deserialization of user-defined types, but it also standardizes how users interact with this crate in terms of Serde.
 
The `SerdeEncoding` trait is used to add values to and fetch values from various wrapper types implementing `Encoding` for `Serialize + DeserializeOwned` types.

Example usage:

```rust
let t = SomeSerdeType::new();

let bucket = store.bucket::<&str, BincodeEncoding<T>>(Some("bucket-name"))?;
let txn = bucket.write_txn()?;

txn.set(&bucket, "some-key", BincodeEncoding::from_serde(t))?;
txn.commit()?
```

Maybe I could implement something like
```rust
impl<T, U> From<T> for U
where
    U: SerdeEncoding<T>,
{
    fn from(t: T) -> Self {
        U::from_serde(t)
    }
}
```
to make usage easier