### PR TITLE
Implement Fail for Error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,15 @@ description = "An embedded key/value store for Rust"
 readme = "README.md"
 
 [dependencies]
-lmdb = { version = "0.8" }
-serde = { version = "1" }
-serde_derive = { version = "1" }
-toml = { version = "0.4" }
-serde_cbor = { version = "0.8", optional = true }
-serde_json = { version = "1", optional = true }
-bincode = { version = "1", optional = true }
+failure = "0.1"
+lmdb = "0.8"
+serde = "1.0"
+serde_derive = "1.0"
+toml = "0.4"
+bincode = { version = "1.0", optional = true }
 capnp = { version = "0.8", optional = true }
+serde_cbor = { version = "0.8", optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [features]
 default = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,31 +2,39 @@ use std::io;
 
 use lmdb;
 
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 /// Error type
 pub enum Error {
     /// An LMDB error
-    LMDB(lmdb::Error),
+    #[fail(display = "Error in LMDB: {}", _0)]
+    LMDB(#[cause] lmdb::Error),
 
     /// An IO error
-    IO(io::Error),
+    #[fail(display = "IO error: {}", _0)]
+    IO(#[cause] io::Error),
 
     /// A non-existant or invalid bucket was used
+    #[fail(display = "Requested bucket doesn't exist")]
     InvalidBucket,
 
     /// A resource could not be found
+    #[fail(display = "Requested key doesn't exist")]
     NotFound,
 
     /// A transaction is readonly but something tried to write to it
+    #[fail(display = "Cannot write in a ReadOnly transaction")]
     ReadOnly,
 
     /// An encoding error
+    #[fail(display = "Could not encode or decode value")]
     InvalidEncoding,
 
     /// Configuration is invalid
+    #[fail(display = "Configuration is invalid")]
     InvalidConfiguration,
 
     /// Directory doesn't exist
+    #[fail(display = "Directory doesn't exist")]
     DirectoryNotFound,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! `kv` is a simple way to embed a key/value store in any application written in Rust
 
+#[macro_use]
+extern crate failure;
 extern crate lmdb;
 extern crate serde;
 #[macro_use]


### PR DESCRIPTION
This will help downstream crates better interact with this crate's errors.