### PR TITLE
Rename `cache_capacity`'s parameter from `ms` to `bytes` to reflect underlying unit in sled

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub struct Config {
     #[serde(default)]
     pub flush_every_ms: Option<u64>,
 
-    /// Specify the cache capacity
+    /// Specify the cache capacity in bytes
     #[serde(default)]
     pub cache_capacity: Option<u64>,
 
@@ -97,8 +97,8 @@ impl Config {
     }
 
     /// Set cache capacity
-    pub fn cache_capacity(mut self, ms: u64) -> Config {
-        self.cache_capacity = Some(ms);
+    pub fn cache_capacity(mut self, bytes: u64) -> Config {
+        self.cache_capacity = Some(bytes);
         self
     }
 


### PR DESCRIPTION
For your consideration.

I believe this parameter is measured in bytes, not miliseconds: https://github.com/spacejam/sled/blob/2259a0b7db75952c9cf2273b18451e6b08ea0c35/src/config.rs#L438

Thank you.