### PR TITLE
chore: update deps (thiserror, toml, rmp-serde)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ all-features = true
 
 [dependencies]
 sled = "0.34"
-thiserror = "1"
-toml = "0.5"
+thiserror = "2"
+toml = "0.9"
 pin-project-lite = "0.2"
 serde = {version = "1", features = ["derive"]}
 serde_json = {version = "1", optional = true}
-rmp-serde = {version = "1.0", optional = true}
+rmp-serde = {version = "1", optional = true}
 bincode = {version = "1.3", optional = true}
 serde-lexpr = {version = "0.1", optional = true}
 


### PR DESCRIPTION
Updates the specified PR title deps.
I would have liked to update bincode too, but that requires a bit of rewrite and making sure stuff doesnt break, so that'll come later on.